### PR TITLE
Decorate by underline for section-title variant

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -132,17 +132,17 @@ const MDXComponents = {
   ),
   //eslint-disable-next-line
   h2: (props: any) => (
+    <DocsHeading as="h2" size="lg" fontWeight="bold" {...props} />
+  ),
+  //eslint-disable-next-line
+  h3: (props: any) => (
     <DocsHeading
-      as="h2"
-      size="lg"
+      as="h3"
+      size="md"
       fontWeight="bold"
       variant="section-title"
       {...props}
     />
-  ),
-  //eslint-disable-next-line
-  h3: (props: any) => (
-    <DocsHeading as="h3" size="md" fontWeight="bold" {...props} />
   ),
   //eslint-disable-next-line
   h4: (props: any) => (

--- a/components/theme.tsx
+++ b/components/theme.tsx
@@ -1,12 +1,29 @@
-import { extendTheme } from '@chakra-ui/react'
+import { defineStyleConfig, extendTheme } from '@chakra-ui/react'
+
+const Heading = defineStyleConfig({
+  variants: {
+    'section-title': {
+      textDecoration: 'underline',
+      fontSize: 20,
+      textUnderlineOffset: 6,
+      textDecorationColor: '#525252',
+      textDecorationThickness: 4,
+      marginTop: 3,
+      marginBottom: 4,
+    },
+  },
+})
 
 const theme = extendTheme({
   styles: {
     global: {
       body: {
-        backgroundColor: 'black',
+        backgroundColor: 'gray.900',
       },
     },
+  },
+  components: {
+    Heading,
   },
 })
 

--- a/mdx/cv.mdx
+++ b/mdx/cv.mdx
@@ -1,6 +1,6 @@
-# j0hnta
+## j0hnta
 
-## Professional Experience
+### Professional Experience
 
 - 2017.9
   - Web Engineering Intern @ VASILY, Inc.
@@ -29,12 +29,12 @@
   - Develop ML systems - keywords: Python, pandas, lightgbm, poetry, GitHub Actions, Fargate / ECS, etc.
     πne
 
-## Education
+### Education
 
 - Tohoku University (BSc. Physics [2014 - 2020])
 - Short-term Study Abroad Program, **National Chengchi University**, Taipei, 2015
 
-## Natural Languages
+### Natural Languages
 
 - English: Business Level, TOEFL iBT 96
 - Japanese: Native Level


### PR DESCRIPTION
Resolve #33 

- 背景色を `black` から `gray.900` に
- h1 -> h2, h2 -> h3 に
- h3 に section-title の variant を追加。その場合は下線でデコレーションするように